### PR TITLE
Fail safe on legacy HIL sensor flow configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ jobs:
           echo "## Installation" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "1. Download the appropriate ZIP file for your platform." >> RELEASE_NOTES.md
-          echo "2. Extract the archive." >> RELEASE_NOTES.md
-          echo "3. Copy the **px4xplane** folder into the \`Resources/plugins\` folder of your X-Plane 11 or 12 installation." >> RELEASE_NOTES.md
-          echo "4. Launch X-Plane and verify the plugin loads from Plugin Admin." >> RELEASE_NOTES.md
+          echo "2. Close X-Plane and remove the existing **px4xplane** plugin folder. Back up custom configs first; do not merge old and new package files." >> RELEASE_NOTES.md
+          echo "3. Extract the archive and copy the complete **px4xplane** folder into the \`Resources/plugins\` folder of your X-Plane 11 or 12 installation." >> RELEASE_NOTES.md
+          echo "4. Launch X-Plane and verify the plugin version and sensor-flow mode in \`Log.txt\`." >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "## Build Information" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [4.2.1] - 2026-08-15
+
+### Fixed
+
+- Migrated the legacy explicit `hil_sensor_flow_control=async` value to the
+  bounded `actuator_feedback` policy so an old `config.ini` cannot silently
+  restore unbounded primary IMU intervals after a plugin upgrade.
+- Made actuator feedback the controller's fail-safe internal default and added
+  direct regression coverage for safe, legacy, invalid, and developer-only
+  flow selections.
+
+### Changed
+
+- Renamed the intentional unbounded comparison mode to `async_unsafe` and
+  added prominent runtime and HUD warnings when it is selected.
+- Clarified clean plugin replacement and estimator-timing troubleshooting so
+  stale binaries and configs are not mixed into a new installation.
+
 ## [4.2.0] - 2026-08-13
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #==============================================================================
 
 cmake_minimum_required(VERSION 3.15)
-project(px4xplane VERSION 4.2.0 LANGUAGES CXX)
+project(px4xplane VERSION 4.2.1 LANGUAGES CXX)
 
 # C++ Standard
 set(CMAKE_CXX_STANDARD 17)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -14,7 +14,7 @@
 
 # Project name
 PROJECT := px4xplane
-VERSION := 4.2.0
+VERSION := 4.2.1
 
 # Compiler
 CXX := g++

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -14,7 +14,7 @@
 
 # Project name
 PROJECT := px4xplane
-VERSION := 4.2.0
+VERSION := 4.2.1
 
 # Compiler
 CXX := clang++

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PX4-XPlane connects PX4 SITL to X-Plane. It sends PX4 actuator commands to
 writable X-Plane datarefs and returns simulated IMU, GPS, barometer,
 magnetometer, airspeed, and ground-truth data.
 
-The current package is `v4.2.0` with Windows, Linux, and macOS builds. It
+The current package is `v4.2.1` with Windows, Linux, and macOS builds. It
 includes tested examples for Cessna 172, TB2, Ehang 184, Alia 250, and
 QuadTailsitter.
 
@@ -38,8 +38,10 @@ project video archive and playlist; future videos will be added there.
 3. Download the latest px4xplane package for your OS from
    [Releases](https://github.com/alireza787b/px4xplane/releases).
 
-4. Extract the archive and copy the complete `px4xplane` folder into the
-   `Resources/plugins` folder of your X-Plane installation, for example
+4. Close X-Plane. If upgrading, back up custom configs and remove the existing
+   `px4xplane` plugin folder; do not merge old and new package files. Extract
+   the archive and copy its complete `px4xplane` folder into X-Plane's
+   `Resources/plugins` folder, for example
    `X-Plane 12/Resources/plugins/px4xplane`.
 
 5. Copy any packaged X-Plane aircraft folders you want to test into an X-Plane
@@ -150,12 +152,14 @@ PX4 X-Plane SITL support is merged in
 [PX4-Autopilot PR #22493](https://github.com/PX4/PX4-Autopilot/pull/22493).
 Use official `PX4/PX4-Autopilot` `main` for normal SITL runs.
 
-`v4.2.0` adds bounded HIL sensor scheduling for uneven or low X-Plane frame
-rates. The plugin now establishes actuator-feedback flow control, keeps at most
+`v4.2.1` uses bounded HIL sensor scheduling for uneven or low X-Plane frame
+rates. The plugin establishes actuator-feedback flow control, keeps at most
 one primary sample outstanding, and splits long frame intervals into bounded
 IMU substeps while preserving elapsed simulation time. It disconnects on a
 feedback, timestamp, or backlog fault instead of silently corrupting estimator
-timing. Existing airframe mappings and PX4 parameters are unchanged.
+timing. Legacy configs that explicitly selected `async` now migrate to the safe
+mode; unbounded developer comparisons require the explicit `async_unsafe`
+value. Existing airframe mappings and PX4 parameters are unchanged.
 
 Several PX4-side fixes found during final X-Plane validation are tracked in
 separate PX4 PRs:

--- a/aircraft/QuadTailsitter/README.md
+++ b/aircraft/QuadTailsitter/README.md
@@ -4,7 +4,7 @@ This aircraft is paired with PX4 airframe `5021_xplane_qtailsitter`.
 
 ## Camera Views
 
-px4xplane v4.2.0 provides config-driven camera views under
+px4xplane v4.2.1 provides config-driven camera views under
 `PX4 X-Plane > Camera Views`. The views are not hardcoded to this aircraft;
 they are read from the active airframe's `cameraViews` line in `config.ini`.
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,5 +1,5 @@
 ; PX4-XPlane Configuration File
-; File Version: 4.2.0
+; File Version: 4.2.1
 ; Last Updated: August 13, 2026
 ; Runtime source of truth for px4xplane actuator, sensor, camera, and UI
 ; settings. The schema JSON is editor/validator metadata only.
@@ -90,8 +90,9 @@ fps_warning_threshold = 50
 ; actuator_feedback mode, the bridge interpolates bounded primary IMU substeps
 ; across long frames and consumes one PX4 response before sending the next.
 ; This does not pause X-Plane physics and is not strict physics lockstep.
-; actuator_feedback is the release default. async is retained for controlled
-; compatibility tests and does not provide the bounded-interval protection.
+; actuator_feedback is the release default. async_unsafe is a developer-only
+; comparison mode and does not provide bounded-interval protection. Legacy
+; configs containing async are migrated to actuator_feedback at runtime.
 ; On feedback timeout or queue overflow, the bridge disconnects instead of
 ; dropping simulation time or continuing with stale actuator state.
 mavlink_sensor_rate_hz = 200

--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -155,12 +155,12 @@
       "type": "string",
       "default": "actuator_feedback",
       "enum": [
-        "async",
-        "actuator_feedback"
+        "actuator_feedback",
+        "async_unsafe"
       ],
       "group": "mavlink_rates",
       "reload_policy": "reconnect_before_flight",
-      "description": "HIL_SENSOR scheduling policy. actuator_feedback is the release default: it allows one primary sensor sample per received PX4 actuator generation and safely interpolates long frame intervals. async is for controlled compatibility tests and does not provide bounded-interval protection."
+      "description": "HIL_SENSOR scheduling policy. actuator_feedback is the release default: it allows one primary sensor sample per received PX4 actuator generation and safely interpolates long frame intervals. async_unsafe is a developer-only comparison mode without bounded-interval protection. The legacy async value is migrated to actuator_feedback at runtime."
     },
     "hil_sensor_feedback_timeout_ms": {
       "type": "int",

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -934,7 +934,7 @@ For automated builds across platforms, the project includes:
 
 ## Version Information
 
-- **Build System Version**: 4.2.0
+- **Build System Version**: 4.2.1
 - **Supported Platforms**:
   - Windows 10+ (Visual Studio 2019/2022, MinGW)
   - macOS 10.14+ (Xcode Command Line Tools, Universal Binary support)
@@ -945,7 +945,7 @@ For automated builds across platforms, the project includes:
   - **Native Makefiles**: Makefile.linux, Makefile.macos
 - **C++ Standard**: C++17
 - **X-Plane SDK**: Latest version included (4.0.0+)
-- **Plugin Version**: 4.2.0
+- **Plugin Version**: 4.2.1
 - **Repository**: [alireza787b/px4xplane](https://github.com/alireza787b/px4xplane)
 
 ## Additional Resources

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -50,18 +50,18 @@ git push origin master && git push origin vX.Y.Z
 
 **1. `include/VersionInfo.h`**
 ```cpp
-constexpr const char* VERSION = "4.2.0";  // Update
+constexpr const char* VERSION = "4.2.1";  // Update
 constexpr const char* BUILD = "001";      // Reset for major/minor, increment for patch
 ```
 
 **2. `CMakeLists.txt`**
 ```cmake
-project(px4xplane VERSION 4.2.0 LANGUAGES CXX)  // Update
+project(px4xplane VERSION 4.2.1 LANGUAGES CXX)  // Update
 ```
 
 **3. `Makefile.linux` and `Makefile.macos`**
 ```make
-VERSION := 4.2.0
+VERSION := 4.2.1
 ```
 
 **4. `docs/config-editor.html`** - Update the displayed editor version/build.
@@ -72,7 +72,7 @@ flight-test cards.
 
 **6. `CHANGELOG.md`** - Add new section at top:
 ```markdown
-## [4.2.0] - 2026-XX-XX
+## [4.2.1] - 2026-XX-XX
 
 ### Added
 - Feature description
@@ -89,12 +89,12 @@ flight-test cards.
 git add CHANGELOG.md CMakeLists.txt Makefile.linux Makefile.macos \
   include/VersionInfo.h docs/config-editor.html README.md docs/index.md \
   config/config.ini docs/*_XPLANE12_TEST.md aircraft/QuadTailsitter/README.md
-git commit -m "Release v4.2.0: Feature name"
+git commit -m "Release v4.2.1: Feature name"
 
 # 3. Tag and push
-git tag -a v4.2.0 -m "Release v4.2.0: Feature name"
+git tag -a v4.2.1 -m "Release v4.2.1: Feature name"
 git push origin master
-git push origin v4.2.0
+git push origin v4.2.1
 
 # 4. Monitor release
 # → https://github.com/alireza787b/px4xplane/actions
@@ -169,21 +169,21 @@ git push origin master && git push origin v4.0.2
 ### New Feature (Minor Release)
 
 ```bash
-# Example: v4.0.x -> v4.2.0
+# Example: v4.0.x -> v4.2.1
 
 # 1. Implement feature and test
 # 2. Update version surfaces listed above
 
 # 3. Release
-git commit -m "Release v4.2.0: New feature"
-git tag -a v4.2.0 -m "Release v4.2.0: New feature"
-git push origin master && git push origin v4.2.0
+git commit -m "Release v4.2.1: New feature"
+git tag -a v4.2.1 -m "Release v4.2.1: New feature"
+git push origin master && git push origin v4.2.1
 ```
 
 ### Breaking Change (Major Release)
 
 ```bash
-# Current: v4.2.0 -> Target: v5.0.0
+# Current: v4.2.1 -> Target: v5.0.0
 
 # 1. Implement breaking change
 # 2. Document migration in CHANGELOG.md (BREAKING CHANGES section)
@@ -258,8 +258,8 @@ tree build/{platform}/Release/px4xplane
 
 ```bash
 # Delete tag locally and remotely
-git tag -d v4.2.0
-git push --delete origin v4.2.0
+git tag -d v4.2.1
+git push --delete origin v4.2.1
 
 # Delete GitHub Release manually
 # Fix version numbers, recommit, re-tag
@@ -313,4 +313,4 @@ px4xplane/
 
 ---
 
-**Last Updated**: 2026-08-13 (px4xplane v4.2.0)
+**Last Updated**: 2026-08-15 (px4xplane v4.2.1)

--- a/docs/assets/config-editor.js
+++ b/docs/assets/config-editor.js
@@ -154,10 +154,10 @@
       hil_sensor_flow_control: {
         type: "string",
         default: "actuator_feedback",
-        enum: ["async", "actuator_feedback"],
+        enum: ["actuator_feedback", "async_unsafe"],
         group: "mavlink_rates",
         reload_policy: "reconnect_before_flight",
-        description: "HIL_SENSOR scheduling policy. actuator_feedback is the release default: it allows one primary sensor sample per received PX4 actuator generation and safely interpolates long frame intervals. async is for controlled compatibility tests and does not provide bounded-interval protection."
+        description: "HIL_SENSOR scheduling policy. actuator_feedback is the release default: it allows one primary sensor sample per received PX4 actuator generation and safely interpolates long frame intervals. async_unsafe is a developer-only comparison mode without bounded-interval protection. The legacy async value is migrated to actuator_feedback at runtime."
       },
       hil_sensor_feedback_timeout_ms: {
         type: "int",

--- a/docs/config-editor.html
+++ b/docs/config-editor.html
@@ -417,7 +417,7 @@
     <div>
       <h1><a href="https://github.com/alireza787b/px4xplane" target="_blank" rel="noreferrer">px4xplane Config Editor</a></h1>
       <div class="headerMeta">
-        <span>v4.2.0</span>
+        <span>v4.2.1</span>
         <span>build 014</span>
         <span>Runtime source: <code>64/config.ini</code></span>
       </div>

--- a/docs/custom-airframe-config.md
+++ b/docs/custom-airframe-config.md
@@ -150,7 +150,7 @@ PX4 actuator outputs are normalized floating-point setpoints, so px4xplane curre
 : X-Plane engine indices that can be braked or feathered when commanded low. Use only when validated for the airframe.
 
 `hil_sensor_flow_control`
-: Primary HIL sensor scheduling policy. Keep the release default, `actuator_feedback`, for normal PX4 SITL use. It permits one primary sensor sample per PX4 actuator response and splits long X-Plane frame intervals into bounded IMU substeps without inventing extra X-Plane physics states. `async` is intended only for controlled compatibility comparisons.
+: Primary HIL sensor scheduling policy. Keep the release default, `actuator_feedback`, for normal PX4 SITL use. It permits one primary sensor sample per PX4 actuator response and splits long X-Plane frame intervals into bounded IMU substeps without inventing extra X-Plane physics states. `async_unsafe` is only for controlled developer comparisons and has no bounded-interval protection. A legacy `async` value is migrated to `actuator_feedback` at runtime.
 
 `hil_sensor_feedback_timeout_ms`
 : Deadline for a queued sensor transmission or the corresponding PX4 actuator response after feedback is established. A timeout disconnects the bridge instead of allowing stale or unbounded sensor traffic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,11 @@ manual address and asks again.
   under the `Resources/plugins` folder of your X-Plane 11 or 12 installation,
   for example `X-Plane 12/Resources/plugins/px4xplane`, then check X-Plane
   `Log.txt` for plugin load errors.
+- High accelerometer bias or unstable velocity with stationary X-Plane truth:
+  close X-Plane, replace the complete plugin folder with the current release,
+  and confirm `Log.txt` reports `v4.2.1` and `FLOW:actuator_feedback`. Do not
+  raise `EKF2_ABL_LIM` or run PX4 level calibration to mask a bridge-timing
+  fault. Remove stale SITL parameter BSON files before the next baseline run.
 - Custom mapping behaves unexpectedly: validate `px4xplane/64/config.ini` from
   the plugin menu or with `python3 tools/validate_config.py config/config.ini`.
 - Actuator-feedback or sensor-queue fault: update to current official PX4
@@ -69,7 +74,7 @@ manual address and asks again.
 
 ## Validation and Maintainer Notes
 
-- Use the `v4.2.0` package with official PX4 `main`. X-Plane SITL support is
+- Use the `v4.2.1` package with official PX4 `main`. X-Plane SITL support is
   merged in
   [PX4-Autopilot #22493](https://github.com/PX4/PX4-Autopilot/pull/22493).
 - The launcher uses official PX4 `main` as the base. Its default is the official

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -177,7 +177,7 @@ public:
     static int mavlink_gps_rate_hz;          // HIL_GPS rate
     static int mavlink_state_rate_hz;        // HIL_STATE_QUATERNION rate
     static int mavlink_rc_rate_hz;           // HIL_RC_INPUTS rate
-    static std::string hil_sensor_flow_control; // async or actuator_feedback
+    static std::string hil_sensor_flow_control; // actuator_feedback or developer-only async_unsafe
     static int hil_sensor_feedback_timeout_ms;  // Socket/output timeout after feedback starts
     static int hil_sensor_feedback_startup_timeout_ms; // Deadline for initial PX4 output
     static float gps_horizontal_accuracy_m;  // HIL_GPS eph, meters

--- a/include/HILSensorFlowController.h
+++ b/include/HILSensorFlowController.h
@@ -1,14 +1,27 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 class HILSensorFlowController {
 public:
     static constexpr uint64_t LOCKSTEP_ACTUATOR_FLAG = 1ULL;
 
     enum class Mode {
-        Async,
+        UnsafeAsync,
         ActuatorFeedback
+    };
+
+    enum class ConfigResolution {
+        Accepted,
+        MigratedLegacyAsync,
+        InvalidFallback
+    };
+
+    struct ConfigSelection {
+        Mode mode;
+        const char* canonicalName;
+        ConfigResolution resolution;
     };
 
     enum class Fault {
@@ -35,9 +48,11 @@ public:
         bool feedback_established{false};
     };
 
-    explicit HILSensorFlowController(Mode mode = Mode::Async,
+    explicit HILSensorFlowController(Mode mode = Mode::ActuatorFeedback,
                                      uint64_t responseTimeoutUsec = 500000,
                                      uint64_t bootstrapTimeoutUsec = 10000000);
+
+    static ConfigSelection resolveConfig(std::string_view configuredMode);
 
     void configure(Mode mode, uint64_t responseTimeoutUsec,
                    uint64_t bootstrapTimeoutUsec);
@@ -53,7 +68,7 @@ public:
     Diagnostics getDiagnostics() const;
 
 private:
-    Mode _mode{Mode::Async};
+    Mode _mode{Mode::ActuatorFeedback};
     uint64_t _responseTimeoutUsec{500000};
     uint64_t _bootstrapTimeoutUsec{10000000};
     uint64_t _generationAtSend{0};

--- a/include/UIConstants.h
+++ b/include/UIConstants.h
@@ -9,7 +9,7 @@
  * @author Alireza Ghaderi
  * @copyright Copyright (c) 2025 Alireza Ghaderi. All rights reserved.
  * @license MIT License
- * @version 4.2.0
+ * @version 4.2.1
  * @url https://github.com/alireza787b/px4xplane
  */
 

--- a/include/VersionInfo.h
+++ b/include/VersionInfo.h
@@ -8,7 +8,7 @@
  * @author Alireza Ghaderi
  * @copyright Copyright (c) 2025 Alireza Ghaderi. All rights reserved.
  * @license MIT License
- * @version 4.2.0
+ * @version 4.2.1
  * @url https://github.com/alireza787b/px4xplane
  */
 
@@ -22,7 +22,7 @@ namespace PX4XPlaneVersion {
     // =================================================================
 
     /** Plugin version string - displayed in UI and About dialog */
-    constexpr const char* VERSION = "4.2.0";
+    constexpr const char* VERSION = "4.2.1";
 
     /** Version phase description */
     constexpr const char* PHASE = "PX4 integration package";
@@ -31,7 +31,7 @@ namespace PX4XPlaneVersion {
     constexpr const char* YEAR = "2026";
 
     /** Plugin build number - increment for each build */
-    constexpr const char* BUILD = "014";
+    constexpr const char* BUILD = "015";
 
     // =================================================================
     // AUTHOR AND PROJECT INFORMATION  

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -1,6 +1,7 @@
 // ConfigManager.cpp
 
 #include "ConfigManager.h"
+#include "HILSensorFlowController.h"
 #include "XPLMUtilities.h"
 #include "XPLMDataAccess.h"
 #include "XPLMPlugin.h"
@@ -194,6 +195,7 @@ void ConfigManager::loadConfiguration() {
     actuatorConfigs.clear();
     cameraViews.clear();
     aircraft_match_tokens.clear();
+    hil_sensor_flow_control = "actuator_feedback";
 
     // Initialize the SimpleIni object and set it to handle Unicode
     CSimpleIniA ini;
@@ -275,7 +277,11 @@ void ConfigManager::loadConfiguration() {
     mavlink_gps_rate_hz = (int)ini.GetLongValue("", "mavlink_gps_rate_hz", 20);
     mavlink_state_rate_hz = (int)ini.GetLongValue("", "mavlink_state_rate_hz", 10);
     mavlink_rc_rate_hz = (int)ini.GetLongValue("", "mavlink_rc_rate_hz", 10);
-    hil_sensor_flow_control = ini.GetValue("", "hil_sensor_flow_control", "actuator_feedback");
+    const std::string configuredSensorFlow =
+        ini.GetValue("", "hil_sensor_flow_control", "actuator_feedback");
+    const auto sensorFlowSelection =
+        HILSensorFlowController::resolveConfig(configuredSensorFlow);
+    hil_sensor_flow_control = sensorFlowSelection.canonicalName;
     hil_sensor_feedback_timeout_ms =
         (int)ini.GetLongValue("", "hil_sensor_feedback_timeout_ms", 500);
     hil_sensor_feedback_startup_timeout_ms =
@@ -300,10 +306,20 @@ void ConfigManager::loadConfiguration() {
         XPLMDebugString("px4xplane: [WARNING] Invalid RC rate, using default 10 Hz\n");
         mavlink_rc_rate_hz = 10;
     }
-    if (hil_sensor_flow_control != "async" &&
-        hil_sensor_flow_control != "actuator_feedback") {
-        XPLMDebugString("px4xplane: [WARNING] Invalid HIL sensor flow control, using actuator_feedback\n");
-        hil_sensor_flow_control = "actuator_feedback";
+    if (sensorFlowSelection.resolution ==
+        HILSensorFlowController::ConfigResolution::MigratedLegacyAsync) {
+        XPLMDebugString(
+            "px4xplane: [WARNING] Legacy hil_sensor_flow_control=async was migrated to "
+            "actuator_feedback. Use async_unsafe only for controlled timing comparisons.\n");
+    } else if (sensorFlowSelection.resolution ==
+               HILSensorFlowController::ConfigResolution::InvalidFallback) {
+        XPLMDebugString(
+            "px4xplane: [WARNING] Invalid HIL sensor flow control, using actuator_feedback\n");
+    }
+    if (sensorFlowSelection.mode == HILSensorFlowController::Mode::UnsafeAsync) {
+        XPLMDebugString(
+            "px4xplane: [WARNING] UNSAFE asynchronous HIL sensor mode enabled; primary IMU "
+            "intervals are not bounded. Do not use this mode for flight validation.\n");
     }
     if (hil_sensor_feedback_timeout_ms < 100 || hil_sensor_feedback_timeout_ms > 5000) {
         XPLMDebugString("px4xplane: [WARNING] Invalid HIL sensor feedback timeout, using 500 ms\n");

--- a/src/HILSensorFlowController.cpp
+++ b/src/HILSensorFlowController.cpp
@@ -1,5 +1,25 @@
 #include "HILSensorFlowController.h"
 
+HILSensorFlowController::ConfigSelection
+HILSensorFlowController::resolveConfig(std::string_view configuredMode)
+{
+    if (configuredMode == "actuator_feedback") {
+        return {Mode::ActuatorFeedback, "actuator_feedback", ConfigResolution::Accepted};
+    }
+
+    if (configuredMode == "async_unsafe") {
+        return {Mode::UnsafeAsync, "async_unsafe", ConfigResolution::Accepted};
+    }
+
+    if (configuredMode == "async") {
+        return {Mode::ActuatorFeedback, "actuator_feedback",
+                ConfigResolution::MigratedLegacyAsync};
+    }
+
+    return {Mode::ActuatorFeedback, "actuator_feedback",
+            ConfigResolution::InvalidFallback};
+}
+
 HILSensorFlowController::HILSensorFlowController(Mode mode,
                                                  uint64_t responseTimeoutUsec,
                                                  uint64_t bootstrapTimeoutUsec)
@@ -105,7 +125,7 @@ void HILSensorFlowController::observeActuator(uint64_t actuatorGeneration,
 
 bool HILSensorFlowController::canSendSensor(uint64_t nowUsec)
 {
-    if (_mode == Mode::Async) {
+    if (_mode == Mode::UnsafeAsync) {
         return true;
     }
 
@@ -158,7 +178,7 @@ void HILSensorFlowController::markSensorQueued(uint64_t actuatorGeneration,
                                                uint64_t nowUsec)
 {
     ++_diagnostics.sensors_queued;
-    if (_mode == Mode::Async) {
+    if (_mode == Mode::UnsafeAsync) {
         return;
     }
 

--- a/src/UIConstants.cpp
+++ b/src/UIConstants.cpp
@@ -9,7 +9,7 @@
  * @author Alireza Ghaderi
  * @copyright Copyright (c) 2025 Alireza Ghaderi. All rights reserved.
  * @license MIT License
- * @version 4.2.0
+ * @version 4.2.1
  * @url https://github.com/alireza787b/px4xplane
  */
 

--- a/src/UIHandler.cpp
+++ b/src/UIHandler.cpp
@@ -17,7 +17,7 @@
  * @author Alireza Ghaderi
  * @copyright Copyright (c) 2025 Alireza Ghaderi. All rights reserved.
  * @license MIT License
- * @version 4.2.0
+ * @version 4.2.1
  * @url https://github.com/alireza787b/px4xplane
  */
 

--- a/src/px4xplane.cpp
+++ b/src/px4xplane.cpp
@@ -942,6 +942,7 @@ static float TARGET_STATE_QUAT_PERIOD = 0.02f;   // Default 50 Hz (updated from 
 static float TARGET_RC_PERIOD = 0.02f;           // Default 50 Hz (updated from config)
 static HILSensorFlowController gHILSensorFlowController;
 static HILSensorResampler gHILSensorResampler;
+static bool gActuatorFeedbackEnabled = true;
 
 // Initialize periods from config (called once during plugin startup)
 void initializeMessagePeriods() {
@@ -950,9 +951,10 @@ void initializeMessagePeriods() {
     TARGET_STATE_QUAT_PERIOD = 1.0f / (float)ConfigManager::mavlink_state_rate_hz;
     TARGET_RC_PERIOD = 1.0f / (float)ConfigManager::mavlink_rc_rate_hz;
 
-    const auto flowMode = ConfigManager::hil_sensor_flow_control == "actuator_feedback"
-        ? HILSensorFlowController::Mode::ActuatorFeedback
-        : HILSensorFlowController::Mode::Async;
+    const auto flowSelection =
+        HILSensorFlowController::resolveConfig(ConfigManager::hil_sensor_flow_control);
+    const auto flowMode = flowSelection.mode;
+    gActuatorFeedbackEnabled = flowMode == HILSensorFlowController::Mode::ActuatorFeedback;
     gHILSensorFlowController.configure(
         flowMode,
         static_cast<uint64_t>(ConfigManager::hil_sensor_feedback_timeout_ms) * 1000ULL,
@@ -1143,7 +1145,7 @@ bool handleSensorFlowFaultIfNeeded()
 	const char* userMessage = nullptr;
 	switch (fault) {
 	case HILSensorFlowController::Fault::BootstrapTimeout:
-		logMessage = "px4xplane: PX4 actuator-feedback startup timed out; disconnecting instead of continuing in async mode.\n";
+		logMessage = "px4xplane: PX4 actuator-feedback startup timed out; disconnecting instead of continuing with unbounded sensor traffic.\n";
 		userMessage = "PX4 actuator feedback did not start. Reconnect SITL.";
 		break;
 	case HILSensorFlowController::Fault::TransmissionTimeout:
@@ -1156,7 +1158,7 @@ bool handleSensorFlowFaultIfNeeded()
 		break;
 	case HILSensorFlowController::Fault::MissingLockstepFlag:
 		logMessage = "px4xplane: PX4 peer did not set the HIL actuator lockstep flag; actuator-feedback flow control requires a lockstep-enabled PX4 peer.\n";
-		userMessage = "PX4 peer is not lockstep-enabled. Use async mode or compatible PX4 SITL.";
+		userMessage = "PX4 peer is not lockstep-enabled. Use compatible PX4 SITL or developer-only async_unsafe mode.";
 		break;
 	case HILSensorFlowController::Fault::None:
 		return false;
@@ -1532,7 +1534,9 @@ float MyFlightLoopCallback(float inElapsedSinceLastCall, float inElapsedTimeSinc
 		// Connection succeeded - reset wait timer and update HUD
 		ConnectionStatusHUD::updateStatus(
 			ConnectionStatusHUD::Status::CONNECTED,
-			"Ready to fly!"
+			gActuatorFeedbackEnabled
+				? "Ready to fly - bounded sensor flow"
+				: "WARNING: connected with unsafe async sensor flow"
 		);
 		waitElapsedTime = 0.0f;
 		wasWaitingForConnection = false;
@@ -1599,8 +1603,7 @@ float MyFlightLoopCallback(float inElapsedSinceLastCall, float inElapsedTimeSinc
 
 	bool sensorSentThisFrame = false;
 
-	const bool actuatorFeedback =
-		ConfigManager::hil_sensor_flow_control == "actuator_feedback";
+	const bool actuatorFeedback = gActuatorFeedbackEnabled;
 	const bool sensorCaptureDue =
 		(currentSimTime - lastSensorSendTime) >= TARGET_SENSOR_PERIOD;
 

--- a/tests/hil_sensor_flow_controller_test.cpp
+++ b/tests/hil_sensor_flow_controller_test.cpp
@@ -8,8 +8,29 @@ int main()
     constexpr uint64_t timeoutUsec = 500000;
     constexpr uint64_t bootstrapTimeoutUsec = 10000000;
 
+    const auto safeConfig = HILSensorFlowController::resolveConfig("actuator_feedback");
+    assert(safeConfig.mode == HILSensorFlowController::Mode::ActuatorFeedback);
+    assert(safeConfig.resolution == HILSensorFlowController::ConfigResolution::Accepted);
+    assert(std::string_view(safeConfig.canonicalName) == "actuator_feedback");
+
+    const auto unsafeConfig = HILSensorFlowController::resolveConfig("async_unsafe");
+    assert(unsafeConfig.mode == HILSensorFlowController::Mode::UnsafeAsync);
+    assert(unsafeConfig.resolution == HILSensorFlowController::ConfigResolution::Accepted);
+    assert(std::string_view(unsafeConfig.canonicalName) == "async_unsafe");
+
+    const auto legacyConfig = HILSensorFlowController::resolveConfig("async");
+    assert(legacyConfig.mode == HILSensorFlowController::Mode::ActuatorFeedback);
+    assert(legacyConfig.resolution ==
+           HILSensorFlowController::ConfigResolution::MigratedLegacyAsync);
+    assert(std::string_view(legacyConfig.canonicalName) == "actuator_feedback");
+
+    const auto invalidConfig = HILSensorFlowController::resolveConfig("typo");
+    assert(invalidConfig.mode == HILSensorFlowController::Mode::ActuatorFeedback);
+    assert(invalidConfig.resolution ==
+           HILSensorFlowController::ConfigResolution::InvalidFallback);
+
     HILSensorFlowController async(
-        HILSensorFlowController::Mode::Async, timeoutUsec, bootstrapTimeoutUsec);
+        HILSensorFlowController::Mode::UnsafeAsync, timeoutUsec, bootstrapTimeoutUsec);
     assert(async.canSendSensor(0));
     async.markSensorQueued(0, 1000000, 1, 0);
     assert(async.canSendSensor(1));

--- a/tests/test_config_editor.js
+++ b/tests/test_config_editor.js
@@ -34,6 +34,10 @@ assert.strictEqual(config.globals.config_name, "Alia250");
 assert.strictEqual(config.sections.length, 1);
 assert.strictEqual(editor.parseMappings(config.sections[0].keys.channel4).length, 2);
 assert(editor.DEFAULT_SCHEMA.airframe_fields.airspeedSource.enum.includes("body_axis"));
+assert.deepStrictEqual(
+  editor.DEFAULT_SCHEMA.global_fields.hil_sensor_flow_control.enum,
+  ["actuator_feedback", "async_unsafe"]
+);
 assert.strictEqual(editor.parseCameras("Forward|1|0|0|0|0|0|0.9; Down|0|0|-1|-90|0|0|0.8").length, 2);
 assert(editor.serializeCameras([{ label: "Chase", forward: "-8", right: "0", up: "2", pitch: "-8", heading: "0", roll: "0", zoom: "0.7" }]).includes("Chase|-8"));
 assert.deepStrictEqual(editor.parseIndices("[0 2 3]"), [0, 2, 3]);
@@ -87,6 +91,10 @@ assert.deepStrictEqual(
 assert.deepStrictEqual(
   Object.keys(editor.DEFAULT_SCHEMA.airframe_fields).sort(),
   Object.keys(repoSchema.airframe_fields).sort()
+);
+assert.deepStrictEqual(
+  editor.DEFAULT_SCHEMA.global_fields.hil_sensor_flow_control,
+  repoSchema.global_fields.hil_sensor_flow_control
 );
 
 console.log("config editor tests passed");

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -99,6 +99,30 @@ class ValidateConfigTest(unittest.TestCase):
         self.assertIn("airspeedSource", schema["airframe_fields"])
         self.assertIn("body_axis", schema["airframe_fields"]["airspeedSource"]["enum"])
         self.assertEqual(schema["global_fields"]["config_name"]["reload_policy"], "reconnect_before_flight")
+        self.assertEqual(
+            schema["global_fields"]["hil_sensor_flow_control"]["enum"],
+            ["actuator_feedback", "async_unsafe"],
+        )
+
+    def test_legacy_async_is_not_exported_as_a_supported_mode(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "config.ini"
+            path.write_text(
+                "\n".join(
+                    [
+                        "config_name = Aircraft",
+                        "hil_sensor_flow_control = async",
+                        "",
+                        "[Aircraft]",
+                        "channel0 = sim/test/ref, float, 0, [0 1]",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            messages = [str(issue) for issue in validate_config.validate_config(path)]
+
+        self.assertTrue(any("expected one of: actuator_feedback, async_unsafe" in message for message in messages))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- migrate legacy `hil_sensor_flow_control=async` configs to the bounded `actuator_feedback` policy
- retain unbounded scheduling only under the explicit developer-only `async_unsafe` name
- make actuator feedback the controller's fail-safe default and show the active safety policy in logs/HUD
- update package replacement and estimator-timing troubleshooting guidance
- release as v4.2.1

## Evidence

A failed QuadTailsitter run on PX4 revision `c7b442d6874c` contained primary IMU integration intervals up to 135 ms (95th percentile 35 ms), including repeated 95-109 ms intervals immediately before estimator divergence. The same stationary segment developed about 2 m/s² of estimated accelerometer bias despite zero GPS/truth velocity and physically sane raw acceleration.

The validated v4.2 actuator-feedback path bounds generated intervals at 15 ms; its prior official-PX4 baseline measured a 14.991 ms maximum and 0.0131 m/s² maximum accelerometer bias. This isolates the regression to a stale binary or an explicitly retained legacy `async` config, not PX4 parameters or the aircraft model.

## Validation

- full Linux plugin build
- 8/8 CTest tests
- 14/14 Python tests
- config editor and schema validation
- focused AddressSanitizer/UBSan flow-policy test
